### PR TITLE
Move API service prefix to config & fix openapi.json issue in nginx

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from app.api.v1.endpoints import blogs
-
+from app.core.config import settings
 api_router = APIRouter()
 
-api_router.include_router(blogs.router, prefix="/blogs") 
+api_router.include_router(blogs.router, prefix=settings.SERVICE_STR) 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -4,6 +4,7 @@ import os
 
 class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
+    SERVICE_STR: str = "/blogs"
     PROJECT_NAME: str = "Blog API"
     BACKEND_CORS_ORIGINS: List[str] = [
         "http://localhost:3000",

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from app.core.service_tracker import initialize_service_start_time
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
-    openapi_url=f"{settings.API_V1_STR}/openapi.json"
+    openapi_url=f"{settings.API_V1_STR}{settings.SERVICE_STR}/openapi.json"
 )
 
 # Initialize service start time tracking


### PR DESCRIPTION
- Move API service prefix to config
- Fix the issue with /docs requesting {{host}}/api/v1/openapi.json. This is not possible to redirect to the correct service easily hence the previous workaround was route this to blog service directly. But that will block docs access to other services if they are using the same openapi url (this can be set in main.py file when defining the `app`). It is not recommended to use the common `/api/v1` to serve the openapi.json rather it should be served on  `/api/v1/{{service-name}}`